### PR TITLE
Console Window

### DIFF
--- a/src/com/strongjoshua/console/Console.java
+++ b/src/com/strongjoshua/console/Console.java
@@ -178,12 +178,8 @@ public class Console implements Disposable {
 		stage.addActor(consoleWindow);
 		stage.setKeyboardFocus(display);
 		
-	
-		
-		//display.setTouchable(Touchable.disabled);
-		
-		//setSizePercent(50, 50);
-		//setPositionPercent(50, 50);
+		setSizePercent(50, 50);
+		setPositionPercent(50, 50);
 	}
 
 	/**
@@ -663,7 +659,7 @@ public class Console implements Disposable {
 				return true;
 			}
 			else if(keycode == keyID) {
-				hidden=!hidden;
+				hidden = !hidden;
 				if(hidden) {
 					input.setText("");
 					stage.setKeyboardFocus(display);


### PR DESCRIPTION
I made the console into a movable and resizable window for my game.
You can see an example here in my game I am working on
http://a.pomf.se/lhvlyw.mp4

It is pretty simple and uses libgdxs default window widget. I just added the ConsoleDisplay onto the window and it worked pretty well.

I've only tested it on my game so I'm not sure how the padding and layout will work with other skins, but it should be fine. My skin is just a modified default skin.

I also added an option to log to the system as well as the console, which could be useful if your game crashes and you can't see the in-game console, the system console is still there.

Maybe you could add an option for choosing between a window and the old full screen method.