### PR TITLE
Makes execCommand() public

### DIFF
--- a/src/com/strongjoshua/console/Console.java
+++ b/src/com/strongjoshua/console/Console.java
@@ -377,7 +377,10 @@ public class Console implements Disposable {
 		exec.setConsole(this);
 	}
 
-	private void execCommand (String command) {
+	/**
+	 * Executes the specified command via the set {@link CommandExecutor}.
+	 */
+	public void execCommand (String command) {
 		log(command, LogLevel.COMMAND);
 
 		String[] parts = command.split(" ");


### PR DESCRIPTION
This would allow developers to read a set of commands from a file at run them at startup, very much like a `.bashrc` file.