### PR TITLE
New features and fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.strongjoshua</groupId>
 	<artifactId>libgdx-inGameConsole</artifactId>
-	<version>0.4.0</version>
+	<version>0.5.0</version>
 	<name>LibGdx In-Game Console</name>
 	<description>This is a LibGdx library that allows a developer to add a console (similar to how it is featured in Source games) to their game.</description>
 

--- a/src/com/strongjoshua/console/AbstractConsole.java
+++ b/src/com/strongjoshua/console/AbstractConsole.java
@@ -193,7 +193,7 @@ public abstract class AbstractConsole implements Console, Disposable {
 	
 	@Override
 	public void printCommands() {
-		Method[] methods = ClassReflection.getDeclaredMethods(this.getClass());
+		Method[] methods = ClassReflection.getDeclaredMethods(exec.getClass());
 		for(int j = 0; j < methods.length; j++) {
 			Method m = methods[j];
 			if(m.isPublic() && canDisplayCommand(m)) {

--- a/src/com/strongjoshua/console/AbstractConsole.java
+++ b/src/com/strongjoshua/console/AbstractConsole.java
@@ -115,6 +115,8 @@ public abstract class AbstractConsole implements Console, Disposable {
 	 */
 	@Override
 	public void execCommand(String command) {
+		if(disabled) return;
+		
 		log(command, LogLevel.COMMAND);
 
 		String[] parts = command.split(" ");

--- a/src/com/strongjoshua/console/CommandCompleter.java
+++ b/src/com/strongjoshua/console/CommandCompleter.java
@@ -22,7 +22,7 @@ class CommandCompleter {
 		Array<Method> methods = getAllMethods(ce);
 		for(Method m : methods) {
 			String name = m.getName();
-			if(name.toLowerCase().startsWith(setString)) {
+			if(name.toLowerCase().startsWith(setString) && ConsoleUtils.canDisplayCommand(ce.console, m)) {
 				possibleCommands.add(name);
 			}
 		}

--- a/src/com/strongjoshua/console/CommandExecutor.java
+++ b/src/com/strongjoshua/console/CommandExecutor.java
@@ -32,7 +32,7 @@ import com.badlogic.gdx.utils.reflect.Method;
  * @author StrongJoshua
  */
 public abstract class CommandExecutor {
-	Console console;
+	protected Console console;
 
 	protected void setConsole(Console c) {
 		console = c;

--- a/src/com/strongjoshua/console/CommandExecutor.java
+++ b/src/com/strongjoshua/console/CommandExecutor.java
@@ -32,7 +32,7 @@ import com.badlogic.gdx.utils.reflect.Method;
  * @author StrongJoshua
  */
 public abstract class CommandExecutor {
-	protected Console console;
+	Console console;
 
 	protected void setConsole(Console c) {
 		console = c;

--- a/src/com/strongjoshua/console/CommandExecutor.java
+++ b/src/com/strongjoshua/console/CommandExecutor.java
@@ -57,24 +57,6 @@ public abstract class CommandExecutor {
 	 * Shows all available methods, and their parameter types, in the console.
 	 */
 	public final void help() {
-		Method[] methods = ClassReflection.getDeclaredMethods(this.getClass());
-		for(int j = 0; j < methods.length; j++) {
-			Method m = methods[j];
-			if(m.isPublic()) {
-				String s = "";
-				s += m.getName();
-				s += " : ";
-
-				Class<?>[] params = m.getParameterTypes();
-				for(int i = 0; i < params.length; i++) {
-					s += params[i].getSimpleName();
-					if(i < params.length - 1) {
-						s += ", ";
-					}
-				}
-
-				console.log(s);
-			}
-		}
+		console.printCommands();
 	}
 }

--- a/src/com/strongjoshua/console/Console.java
+++ b/src/com/strongjoshua/console/Console.java
@@ -90,6 +90,9 @@ public interface Console {
 	 * @param fh The {@link FileHandle} that links to the file to be written to. Note that <code>classpath</code> and
 	 *           <code>internal</code> FileHandles cannot be written to. */
 	public void printLogToFile(FileHandle fh);
+	
+	/** Prints all commands */
+	public void printCommands();
 
 	/** @return If the console is disabled.
 	 * @see Console#setDisabled(boolean) */
@@ -128,5 +131,16 @@ public interface Console {
 
 	/** @return If console is hidden */
 	public boolean isHidden();
-
+	
+	/** Sets the executeHiddenCommands field
+	 * 
+	 * @param enabled - if true, commands annotated with {@link HiddenCommand} can be executed
+	 */
+	public void setExecuteHiddenCommands(boolean enabled);
+	
+	/** Sets the executeHiddenCommands field
+	 * 
+	 * @param enabled - if true, commands annotated with {@link HiddenCommand} show when printCommands (help) is executed
+	 */
+	public void setDisplayHiddenCommands(boolean enabled);
 }

--- a/src/com/strongjoshua/console/Console.java
+++ b/src/com/strongjoshua/console/Console.java
@@ -143,4 +143,16 @@ public interface Console {
 	 * @param enabled - if true, commands annotated with {@link HiddenCommand} show when printCommands (help) is executed
 	 */
 	public void setDisplayHiddenCommands(boolean enabled);
+	
+	/**
+	 * 
+	 * @return If hidden commands can be executed
+	 */
+	public boolean isExecuteHiddenCommandsEnabled();
+	
+	/**
+	 * 
+	 * @return If hidden commands can be displayed
+	 */
+	public boolean isDisplayHiddenCommandsEnabled();
 }

--- a/src/com/strongjoshua/console/ConsoleUtils.java
+++ b/src/com/strongjoshua/console/ConsoleUtils.java
@@ -1,0 +1,30 @@
+/**
+ * 
+ */
+package com.strongjoshua.console;
+
+import com.badlogic.gdx.utils.reflect.Method;
+
+/**
+ * @author Eric
+ *
+ */
+public final class ConsoleUtils {
+	
+	public static boolean canExecuteCommand(Console console, Method method) {
+		if(!console.isExecuteHiddenCommandsEnabled() && method.isAnnotationPresent(HiddenCommand.class)) {
+			return false;
+		}
+		
+		return true;
+	}
+	
+	public static boolean canDisplayCommand(Console console, Method method) {
+		if(!console.isDisplayHiddenCommandsEnabled() && method.isAnnotationPresent(HiddenCommand.class)) {
+			return false;
+		}
+		
+		return true;
+	}
+
+}

--- a/src/com/strongjoshua/console/HiddenCommand.java
+++ b/src/com/strongjoshua/console/HiddenCommand.java
@@ -1,0 +1,23 @@
+/**
+ * 
+ */
+package com.strongjoshua.console;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Eric Burns (ThaBalla1148)
+ *
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HiddenCommand {
+
+}

--- a/test/com/strongjoshua/console/ConsoleTest.java
+++ b/test/com/strongjoshua/console/ConsoleTest.java
@@ -1,0 +1,154 @@
+/**
+ * 
+ */
+package com.strongjoshua.console;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Eric
+ *
+ */
+public class ConsoleTest {
+	
+	private Console	headlessConsole;
+	private CommandExecutor commandExec;
+	private boolean commandFound;
+	
+	@Before
+	public void setup() {
+		commandFound = false;
+		headlessConsole = new HeadlessConsole();
+		commandExec = new CommandExecutor() {
+			
+			public void testString(String str) {
+				commandFound = true;
+				
+				console.log(str);
+			}
+			
+			public void testBoolean(Boolean arg1, boolean arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testByte(Byte arg1, byte arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testShort(Short arg1, short arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testInteger(Integer arg1, int arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testLong(Long arg1, long arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testFloat(Float arg1, float arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testDouble(Double arg1, double arg2) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+				console.log(String.valueOf(arg2));
+			}
+			
+			public void testObject(Object arg1) {
+				commandFound = true;
+				
+				console.log(String.valueOf(arg1));
+			}
+		};
+		
+		headlessConsole.setCommandExecutor(commandExec);
+	}
+	
+	@Test
+	public void test_StringArgument() {
+		headlessConsole.execCommand("testString STRING");
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_BooleanArgument() {
+		headlessConsole.execCommand("testBoolean true false");
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_ByteArgument() {
+		headlessConsole.execCommand("testByte " + Byte.MAX_VALUE + " " + Byte.MIN_VALUE);
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_ShortArgument() {
+		headlessConsole.execCommand("testShort " + Short.MAX_VALUE + " " + Short.MIN_VALUE);
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_IntegerArgument() {
+		headlessConsole.execCommand("testInteger " + Integer.MAX_VALUE + " " + Integer.MIN_VALUE);
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_LongArgument() {
+		headlessConsole.execCommand("testLong " + Long.MAX_VALUE + " " + Long.MIN_VALUE);
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_FloatArgument() {
+		headlessConsole.execCommand("testFloat " + Float.MAX_VALUE + " " + Float.MIN_VALUE);
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_DoubleArgument() {
+		headlessConsole.execCommand("testDouble " + Double.MAX_VALUE + " " + Double.MIN_VALUE);
+		
+		assertTrue(commandFound);
+	}
+	
+	@Test
+	public void test_ObjectArgument() {
+		headlessConsole.execCommand("testObject test test");
+		
+		assertFalse(commandFound);
+	}
+
+}

--- a/test/tests/Box2DTest.java
+++ b/test/tests/Box2DTest.java
@@ -257,7 +257,7 @@ public class Box2DTest extends ApplicationAdapter {
 		
 		@HiddenCommand
 		public void superExplode() {
-			explode(0, 0, 10000);
+			explode(0, 0, 1000000);
 		}
 		
 		public void setExecuteHiddenCommands(boolean enabled) {

--- a/test/tests/Box2DTest.java
+++ b/test/tests/Box2DTest.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.strongjoshua.console.CommandExecutor;
 import com.strongjoshua.console.Console;
 import com.strongjoshua.console.GUIConsole;
+import com.strongjoshua.console.HiddenCommand;
 import com.strongjoshua.console.LogLevel;
 
 /**
@@ -253,6 +254,22 @@ public class Box2DTest extends ApplicationAdapter {
 	}
 
 	public class MyCommandExecutor extends CommandExecutor {
+		
+		@HiddenCommand
+		public void superExplode() {
+			explode(0, 0, 10000);
+		}
+		
+		public void setExecuteHiddenCommands(boolean enabled) {
+			console.setExecuteHiddenCommands(enabled);
+			console.log("ExecuteHiddenCommands was set to " + enabled);
+		}
+		
+		public void setDisplayHiddenCommands(boolean enabled) {
+			console.setDisplayHiddenCommands(enabled);
+			console.log("DisplayHiddenCommands was set to " + enabled);
+		}
+		
 		public void explode(float x, float y, float maxForce) {
 			createExplosion(x, y, maxForce);
 			console.log("Created console explosion!", LogLevel.SUCCESS);


### PR DESCRIPTION
**Implemented HiddenCommand annotation for CommandExecutor methods**
- Using this annotation allows commands to either be hidden from help command and auto-complete or disabled from being executable. Supports both simultaneously.
- By default, hidden commands are executable, but are hidden from displaying.

**Moved logic for CommandExecutor.print() to Console.printCommands()**
- This was done to better support the new HiddenCommand annotation

**Fixed console not being disabled while not using GUIConsole if disabled flag was set**

**Refactored and updated method and argument determination/parsing code**
- Now supports String, Boolean, Byte, Short, Integer, Long, Float, Double, and their primitive counter-parts

**Updated Box2DTest with HiddenCommand methods**

**Added ConsoleTest**
- Tests all supported Command argument types
