### PR TITLE
Small change to CommandExecutor.java

### DIFF
--- a/src/com/strongjoshua/console/CommandExecutor.java
+++ b/src/com/strongjoshua/console/CommandExecutor.java
@@ -33,7 +33,7 @@ import com.strongjoshua.console.annotation.ConsoleDoc;
  *
  * @author StrongJoshua
  */
-public abstract class CommandExecutor {
+public class CommandExecutor {
 	protected Console console;
 
 	protected void setConsole (Console c) {


### PR DESCRIPTION
There is no need for the Command Executor to be abstract. Makes it less intuitive to test when starting out.