### PR TITLE
Minor Bug Fixes

### DIFF
--- a/src/com/strongjoshua/console/AbstractConsole.java
+++ b/src/com/strongjoshua/console/AbstractConsole.java
@@ -69,11 +69,11 @@ public abstract class AbstractConsole implements Console, Disposable {
 		this.log(msg, LogLevel.DEFAULT);
 	}
 
-	@Override public void log (Exception exception, LogLevel level) {
+	@Override public void log (Throwable exception, LogLevel level) {
 		this.log(ConsoleUtils.exceptionToString(exception), level);
 	}
 
-	@Override public void log (Exception exception) {
+	@Override public void log (Throwable exception) {
 		this.log(exception, LogLevel.ERROR);
 	}
 

--- a/src/com/strongjoshua/console/CommandCompleter.java
+++ b/src/com/strongjoshua/console/CommandCompleter.java
@@ -19,7 +19,7 @@ import com.badlogic.gdx.utils.ObjectSet.ObjectSetIterator;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.Method;
 
-class CommandCompleter {
+public class CommandCompleter {
 	private ObjectSet<String> possibleCommands;
 	private ObjectSetIterator<String> iterator;
 	private String setString;

--- a/src/com/strongjoshua/console/CommandHistory.java
+++ b/src/com/strongjoshua/console/CommandHistory.java
@@ -15,7 +15,7 @@ package com.strongjoshua.console;
 
 import com.badlogic.gdx.utils.Array;
 
-class CommandHistory {
+public class CommandHistory {
 	private final Array<String> commands = new Array<>(true, 20);
 	private int index;
 

--- a/src/com/strongjoshua/console/ConsoleContext.java
+++ b/src/com/strongjoshua/console/ConsoleContext.java
@@ -9,7 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 
-class ConsoleContext extends Table {
+public class ConsoleContext extends Table {
 	private Label label, copy;
 	private InputListener stageListener;
 

--- a/src/com/strongjoshua/console/Log.java
+++ b/src/com/strongjoshua/console/Log.java
@@ -19,7 +19,7 @@ import com.badlogic.gdx.utils.Array;
 import java.io.IOException;
 import java.io.Writer;
 
-class Log {
+public class Log {
 	private Array<LogEntry> logEntries;
 	private int numEntries = Console.UNLIMITED_ENTRIES;
 

--- a/src/com/strongjoshua/console/LogEntry.java
+++ b/src/com/strongjoshua/console/LogEntry.java
@@ -16,7 +16,7 @@ package com.strongjoshua.console;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.TimeUtils;
 
-class LogEntry {
+public class LogEntry {
 	private String text;
 	private LogLevel level;
 	private long timeStamp;


### PR DESCRIPTION
Two minor bug fixes. Changed the access modifies of five classes to from default public and fixed the parameters of two methods.

Change the parameters of the exception logging methods to use Throwable instead of Exception.
ConsoleUtils.exceptionToString already uses Throwables.

Made the following classes public:

1. CommandCompleter.java
2. CommandHistory.java
3. ConsoleContext.java
4. Log.java
5. LogEntry.java