### PR TITLE
Up arrow key repeats the same command after pressing enter rather tha…

### DIFF
--- a/src/com/strongjoshua/console/GUIConsole.java
+++ b/src/com/strongjoshua/console/GUIConsole.java
@@ -612,6 +612,7 @@ public class GUIConsole extends AbstractConsole {
 			}
 
 			if (keycode == Keys.ENTER && !hidden) {
+				commandHistory.getNextCommand(); // Makes up arrow key repeat the same command after pressing enter
 				return display.submit();
 			} else if (keycode == Keys.UP && !hidden) {
 				input.setText(commandHistory.getPreviousCommand());


### PR DESCRIPTION
Allows you to spam up arrow and enter to repeat the same command over and over, like in most consoles.

Pressing up arrow again resumes normal behaviour of going through the previous commands

#43  

Signed-off-by: Draika <risole123@hotmail.com>