### PR TITLE
Commands now give useful error messages even without consoleTrace active

### DIFF
--- a/src/com/strongjoshua/console/AbstractConsole.java
+++ b/src/com/strongjoshua/console/AbstractConsole.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.utils.reflect.Method;
 import com.badlogic.gdx.utils.reflect.ReflectionException;
 import com.strongjoshua.console.annotation.ConsoleDoc;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -188,6 +189,11 @@ public abstract class AbstractConsole implements Console, Disposable {
 					log(msg, LogLevel.ERROR);
 					if (consoleTrace) {
 						log(e, LogLevel.ERROR);
+					} else if (e.getCause() instanceof InvocationTargetException) {
+						Throwable originalException = e.getCause().getCause();
+						if (originalException != null) {
+							log(originalException.getClass().getName() + ": " + originalException.getMessage(), LogLevel.ERROR);
+						}
 					}
 					return;
 				}


### PR DESCRIPTION
When `consoleTrace` is set to **false**, exceptions in commands will lead to useless messages:

`Exception occurred in method: failFunction`

This is caused by the fact that `com.badlogic.gdx.utils.reflect.invoke()` wraps the `TargetInvokationException` with a `ReflectionException` with that predefined message, therefore the check for an empty message in `AbstractConsole` is never true in that case.

```
if (msg == null || msg.length() <= 0) {
  msg = "Unknown Error";
  e.printStackTrace();
}
```

With this change the example `failFunction` command in `Box2DTest` will print the much more helpful: 

```
Exception occurred in method: failFunction
java.lang.RuntimeException: This function was designed to fail.
```


Only tested on desktop. If it causes issues with GWT, the import might need to be avoided, but so far untested.